### PR TITLE
v2.1.2: Add GitHub Pages documentation site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to advanced-brainfuck will be documented in this file.
 
+## [2.1.2] - 20260503
+
+### Added
+
+- GitHub Pages documentation site (`docs/index.html`) with project branding
+- Static documentation landing page linking to specs, ADRs, source, and PyPI
+
 ## [2.1.1] - 20260503
 
 ### Removed

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>advanced-brainfuck — Documentation</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --void:          #0B1026;
+      --void-mid:      #101830;
+      --surface:       #1A1E26;
+      --surface-mid:   #2D333B;
+      --surface-dark:  #444C56;
+      --accent:        #FFB800;
+      --accent-dim:    #CC9300;
+      --bracket:       #6A7AA0;
+      --text:          #E0E0E0;
+      --text-dim:      #C0C0C0;
+      --text-dark:     #8B949E;
+      --white:         #FFFFFF;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: "SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace;
+      background: var(--void);
+      color: var(--text);
+      min-height: 100vh;
+    }
+
+    body::before, body::after {
+      content: "";
+      display: block;
+      height: 3px;
+      background: linear-gradient(90deg, transparent 0%, var(--accent) 30%, var(--accent) 70%, transparent 100%);
+      opacity: 0.5;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      padding: 2.5rem 3rem 1.5rem;
+      border-bottom: 1px solid var(--surface-mid);
+      max-width: 960px;
+      margin: 0 auto;
+    }
+
+    .logo-wrap svg { width: 64px; height: 64px; }
+
+    .header-text h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: var(--white);
+    }
+    .header-text h1 .bf-brackets { color: var(--bracket); }
+    .header-text h1 .bf-dot { color: var(--accent); }
+    .header-text p {
+      font-size: 0.9rem;
+      color: var(--text-dim);
+      margin-top: 0.2rem;
+    }
+
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 2.5rem 3rem 4rem;
+    }
+
+    .section-title {
+      font-size: 0.65rem;
+      font-weight: 600;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin-bottom: 1rem;
+      padding-bottom: 0.4rem;
+      border-bottom: 1px solid var(--surface-mid);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .section-title::before {
+      content: "[";
+      display: inline-block;
+      color: var(--bracket);
+      font-size: 0.8rem;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+    .section-title::after {
+      content: "]";
+      display: inline-block;
+      color: var(--bracket);
+      font-size: 0.8rem;
+      font-weight: 700;
+    }
+
+    .docs-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1.25rem;
+      margin-bottom: 3rem;
+    }
+
+    a.doc-card {
+      display: block;
+      background: var(--void-mid);
+      border: 1px solid var(--surface-mid);
+      border-left: 3px solid var(--accent);
+      border-radius: 4px;
+      padding: 1.5rem 1.25rem;
+      text-decoration: none;
+      color: inherit;
+      transition: border-left-color 0.15s, box-shadow 0.15s;
+    }
+    a.doc-card:hover {
+      border-left-color: var(--white);
+      box-shadow: 0 0 16px rgba(255, 184, 0, 0.1);
+    }
+
+    .doc-card-label {
+      font-size: 0.6rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin-bottom: 0.4rem;
+    }
+    .doc-card-title {
+      font-size: 1.05rem;
+      color: var(--white);
+      margin-bottom: 0.35rem;
+    }
+    .doc-card-desc {
+      font-size: 0.82rem;
+      color: var(--text-dark);
+      line-height: 1.5;
+    }
+
+    footer {
+      border-top: 1px solid var(--surface-mid);
+      padding: 1.5rem 3rem;
+      max-width: 960px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.75rem;
+      color: var(--text-dark);
+    }
+    footer a { color: var(--accent); text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+
+    @media (max-width: 600px) {
+      header, main, footer { padding-left: 1.25rem; padding-right: 1.25rem; }
+      .docs-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+
+  <header>
+    <div class="logo-wrap">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="advanced-brainfuck logo">
+        <rect width="512" height="512" fill="#0B1026" rx="16"/>
+        <rect x="75" y="75" width="18" height="362" rx="6" fill="#6A7AA0"/>
+        <rect x="75" y="75" width="90" height="18" rx="6" fill="#6A7AA0"/>
+        <rect x="75" y="419" width="90" height="18" rx="6" fill="#6A7AA0"/>
+        <rect x="419" y="75" width="18" height="362" rx="6" fill="#6A7AA0"/>
+        <rect x="347" y="75" width="90" height="18" rx="6" fill="#6A7AA0"/>
+        <rect x="347" y="419" width="90" height="18" rx="6" fill="#6A7AA0"/>
+        <polygon points="130,256 195,195 195,225 150,256 195,287 195,317" fill="#F0F0F0"/>
+        <circle cx="256" cy="256" r="45" fill="#FFB800"/>
+        <polygon points="382,256 317,195 317,225 362,256 317,287 317,317" fill="#F0F0F0"/>
+      </svg>
+    </div>
+    <div class="header-text">
+      <h1><span class="bf-brackets">[</span>advanced-brain<span class="bf-dot">f*</span>ck<span class="bf-brackets">]</span></h1>
+      <p>A high-performance Brainfuck interpreter for Python with JIT acceleration.</p>
+    </div>
+  </header>
+
+  <main>
+
+    <p class="section-title">Getting Started</p>
+    <div class="docs-grid">
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/README.md">
+        <div class="doc-card-label">Quick Start</div>
+        <div class="doc-card-title">README</div>
+        <div class="doc-card-desc">Installation, usage, commands, and library modules</div>
+      </a>
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/CHANGELOG.md">
+        <div class="doc-card-label">Releases</div>
+        <div class="doc-card-title">Changelog</div>
+        <div class="doc-card-desc">Version history, release codenames, and change log</div>
+      </a>
+      <a class="doc-card" href="https://pypi.org/project/advanced-brainfuck/">
+        <div class="doc-card-label">Package</div>
+        <div class="doc-card-title">PyPI</div>
+        <div class="doc-card-desc">Install with pip install advanced-brainfuck</div>
+      </a>
+    </div>
+
+    <p class="section-title">Stakeholder</p>
+    <div class="docs-grid">
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/docs/spec/product_definition.md">
+        <div class="doc-card-label">Product</div>
+        <div class="doc-card-title">Product Definition</div>
+        <div class="doc-card-desc">What the product is, who it's for, scope boundaries, and quality attributes</div>
+      </a>
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/docs/spec/glossary.md">
+        <div class="doc-card-label">Language</div>
+        <div class="doc-card-title">Glossary</div>
+        <div class="doc-card-desc">Domain terms and ubiquitous language definitions</div>
+      </a>
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/docs/branding/branding.md">
+        <div class="doc-card-label">Identity</div>
+        <div class="doc-card-title">Branding</div>
+        <div class="doc-card-desc">Visual identity, colour palette, logo, banner, and release naming</div>
+      </a>
+    </div>
+
+    <p class="section-title">Architect</p>
+    <div class="docs-grid">
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/docs/spec/system.md">
+        <div class="doc-card-label">Architecture</div>
+        <div class="doc-card-title">System Overview</div>
+        <div class="doc-card-desc">Current-state snapshot, domain model, context tables, ADR index</div>
+      </a>
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/docs/spec/technical_design.md">
+        <div class="doc-card-label">Architecture</div>
+        <div class="doc-card-title">Technical Design</div>
+        <div class="doc-card-desc">Stack, module structure, API contracts, JIT execution, configuration</div>
+      </a>
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/docs/spec/context_map.md">
+        <div class="doc-card-label">Architecture</div>
+        <div class="doc-card-title">Context Map</div>
+        <div class="doc-card-desc">Bounded context relationships and integration points</div>
+      </a>
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/docs/spec/domain_model.md">
+        <div class="doc-card-label">Architecture</div>
+        <div class="doc-card-title">Domain Model</div>
+        <div class="doc-card-desc">Entities, relationships, and aggregate boundaries</div>
+      </a>
+    </div>
+
+    <p class="section-title">Decisions</p>
+    <div class="docs-grid">
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/docs/adr/ADR_20260502_ir_compilation.md">
+        <div class="doc-card-label">ADR</div>
+        <div class="doc-card-title">IR Compilation</div>
+        <div class="doc-card-desc">Run-length encoding and pre-resolved jump targets</div>
+      </a>
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/docs/adr/ADR_20260502_jit_acceleration.md">
+        <div class="doc-card-label">ADR</div>
+        <div class="doc-card-title">JIT Acceleration</div>
+        <div class="doc-card-desc">Numba JIT-compiled execution path for Brainfuck programs</div>
+      </a>
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/blob/main/docs/adr/ADR_20260503_segmented_jit.md">
+        <div class="doc-card-label">ADR</div>
+        <div class="doc-card-title">Segmented JIT</div>
+        <div class="doc-card-desc">Checkpoint/resume execution for I/O operations in all programs</div>
+      </a>
+    </div>
+
+    <p class="section-title">Engineer</p>
+    <div class="docs-grid">
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/tree/main/brainfuck">
+        <div class="doc-card-label">Reference</div>
+        <div class="doc-card-title">Source Code</div>
+        <div class="doc-card-desc">Browse the brainfuck package, core interpreter, and JIT engine</div>
+      </a>
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/tree/main/tests">
+        <div class="doc-card-label">Quality</div>
+        <div class="doc-card-title">Test Suite</div>
+        <div class="doc-card-desc">Unit and feature tests, 36 passing</div>
+      </a>
+      <a class="doc-card" href="https://github.com/nullhack/advanced-brainfuck/tree/main/brainfuck/bflib">
+        <div class="doc-card-label">Library</div>
+        <div class="doc-card-title">bflib Modules</div>
+        <div class="doc-card-desc">31 reusable Brainfuck library modules (sum, copy, mul, div, ...)</div>
+      </a>
+    </div>
+
+  </main>
+
+  <footer>
+    <span>Generated documentation</span>
+    <span>advanced-brainfuck &nbsp;&middot;&nbsp; <a href="https://github.com/nullhack/advanced-brainfuck">github.com/nullhack/advanced-brainfuck</a></span>
+  </footer>
+
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "advanced-brainfuck"
-version = "2.1.1"
+version = "2.1.2"
 description = "High-performance Brainfuck interpreter with JIT acceleration, library imports, and interactive REPL"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

- Add static documentation landing page (`docs/index.html`) styled with project branding (navy/gold/white)
- Links to README, changelog, PyPI, specs, ADRs, source code, and test suite
- Enable GitHub Pages from `docs/` folder on `main` branch
- Bump version to 2.1.2

## Pattern

Follows the same `docs/index.html` pattern as [nullhack/agents-smith](https://github.com/nullhack/agents-smith) — a self-contained static page that links to GitHub-hosted markdown files.

## GitHub Pages

Already configured via API: `source: main /docs` → https://nullhack.github.io/advanced-brainfuck/