### PR TITLE
v2.1.3: Fix CLI entry point argument parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to advanced-brainfuck will be documented in this file.
 
+## [2.1.3] - 20260503
+
+### Fixed
+
+- CLI entry point now correctly parses arguments (`main()` was using default `args=[]` instead of `sys.argv`)
+
 ## [2.1.2] - 20260503
 
 ### Added

--- a/brainfuck/core.py
+++ b/brainfuck/core.py
@@ -708,7 +708,7 @@ class Cells:
         return ' '.join(print_list)
 
 
-def main(args=[]):
+def main(args=None):
     """Config parser and run command line options."""
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "advanced-brainfuck"
-version = "2.1.2"
+version = "2.1.3"
 description = "High-performance Brainfuck interpreter with JIT acceleration, library imports, and interactive REPL"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

- Fix `main()` default args from `[]` to `None` so argparse reads `sys.argv` correctly
- The console script entry point calls `main()` with no args, which previously parsed an empty list instead of CLI arguments
- All CLI flags (`-c`, `-f`, `-r`) now work correctly when invoked via the `brainfuck` command

## Bug

```bash
# Before fix: -c flag was ignored, REPL started anyway
brainfuck -c "++++++++."
# → entered REPL instead of executing

# After fix: works correctly
brainfuck -c "++++++++."
# → prints chr(8) and exits
```

## Test

```bash
brainfuck -c "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++."
# → Hello World!

brainfuck -c -f LostKng.b
# → runs 2.1MB program (fixes #2)
```